### PR TITLE
working minimal json template, updated readme

### DIFF
--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -6,13 +6,58 @@ To run the template you will need to have the AWS CLI installed.  Instruction on
 
     aws configure
 
+You will also need to [create a KeyPair](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) named *dse_keypair* and save the .pem file to *~/.ssh/*
+
 ## Creating a Cluster
+**Note: _deploy.sh_ only creates one node at the moment!**
 
 To create a cluster run the command:
 
     ./deploy.sh myteststack
-    
-It takes one argument, the name of the stack to create.  The script then validates the template and deploys it to create a cluster.
+
+It takes one argument, the name of the stack to create.  The script then validates the template and deploys it to create a cluster (printing json as shown below).
+
+```
+$ ./deploy.sh myteststack
+
+{
+    "Description": "AWS CloudFormation Sample Template DataStax Enterprise: Create a DSE stack using a single EC2 instance. This template demonstrates using the AWS CloudFormation bootstrap scripts to install the packages and files necessary to deploy DSE. **WARNING** This template creates an Amazon EC2 instance. You will be billed for the AWS resources used if you create a stack from this template.",
+    "Parameters": [
+        {
+            "NoEcho": false,
+            "Description": "Name of an existing EC2 KeyPair to enable SSH access to the instance",
+            "ParameterKey": "KeyName"
+        },
+        {
+            "DefaultValue": "0.0.0.0/0",
+            "NoEcho": false,
+            "Description": " The IP address range that can be used to SSH to the EC2 instances",
+            "ParameterKey": "SSHLocation"
+        },
+        {
+            "DefaultValue": "t2.medium",
+            "NoEcho": false,
+            "Description": "WebServer EC2 instance type",
+            "ParameterKey": "InstanceType"
+        }
+    ]
+}
+{
+    "StackId": "arn:aws:cloudformation:us-west-2:631542882297:stack/dsestack/a6772730-6a0b-11e6-ac3f-500c593b9a36"
+}
+```
+Once the instance is running (which may take several minutes) you can ssh to its public ip and see that DSE is running.
+```
+$ ssh -i ~/.ssh/dse_keypair.pem ubuntu@52.88.228.9
+.......
+ubuntu@ip-172-31-22-164:~$ cqlsh
+Connected to Test Cluster at 127.0.0.1:9042.
+[cqlsh 5.0.1 | Cassandra 3.0.7.1159 | DSE 5.0.1 | CQL spec 3.4.0 | Native protocol v4]
+Use HELP for help.
+cqlsh>
+
+```
+Tip: if you're changing the template and creating/destroying the instance you may need to delete the key's entry from *~/.ssh/known_hosts*
 
 ## Working with a Cluster
 

--- a/quickstart/deploy.sh
+++ b/quickstart/deploy.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-aws cloudformation validate-template --template-body file://onemachine.json
+aws cloudformation validate-template \
+--template-body "$(cat ./onemachine.json)"
 
-KeyName=datastax
-aws cloudformation create-stack --stack-name myteststack --template-body file://onemachine.json --parameters  ParameterKey=KeyName,ParameterValue=$KeyName
+aws cloudformation create-stack \
+--stack-name $1 \
+--template-body "$(cat ./onemachine.json)" \
+--parameters \
+ParameterKey=KeyName,ParameterValue="dse_keypair"

--- a/quickstart/onemachine.json
+++ b/quickstart/onemachine.json
@@ -1,40 +1,27 @@
 {
-  "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "Amazon CloudFormation template for DataStax Enterprise",
-  "Parameters": {
-    "InstanceType": {
-      "Description": "WebServer EC2 instance type",
-      "Type": "String",
-      "Default": "m1.small",
-      "AllowedValues": [
-        "t1.micro",
-        "m1.small",
-        "m1.medium",
-        "m1.large",
-        "m1.xlarge",
-        "m2.xlarge",
-        "m2.2xlarge",
-        "m2.4xlarge",
-        "m3.xlarge",
-        "m3.2xlarge",
-        "c1.medium",
-        "c1.xlarge",
-        "cc1.4xlarge",
-        "cc2.8xlarge",
-        "cg1.4xlarge"
-      ],
-      "ConstraintDescription": "must be a valid EC2 instance type."
-    },
+  "AWSTemplateFormatVersion" : "2010-09-09",
+
+  "Description" : "AWS CloudFormation Sample Template DataStax Enterprise: Create a DSE stack using a single EC2 instance. This template demonstrates using the AWS CloudFormation bootstrap scripts to install the packages and files necessary to deploy DSE. **WARNING** This template creates an Amazon EC2 instance. You will be billed for the AWS resources used if you create a stack from this template.",
+
+  "Parameters" : {
+
     "KeyName": {
-      "Description": "Name of an existing EC2 KeyPair to enable SSH access to the instance",
-      "Type": "String",
-      "MinLength": "1",
-      "MaxLength": "255",
-      "AllowedPattern": "[\\x20-\\x7E]*",
-      "ConstraintDescription": "can contain only ASCII characters."
+      "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the instance",
+      "Type": "AWS::EC2::KeyPair::KeyName",
+      "ConstraintDescription" : "must be the name of an existing EC2 KeyPair."
     },
-    "SSHLocation": {
-      "Description": " The IP address range that can be used to SSH to the EC2 instances",
+
+    "InstanceType" : {
+      "Description" : "WebServer EC2 instance type",
+      "Type" : "String",
+      "Default" : "t2.medium",
+      "AllowedValues" : [ "t1.micro", "t2.nano", "t2.micro", "t2.small", "t2.medium", "t2.large"]
+,
+      "ConstraintDescription" : "must be a valid EC2 instance type."
+    },
+
+    "SSHLocation" : {
+      "Description" : " The IP address range that can be used to SSH to the EC2 instances",
       "Type": "String",
       "MinLength": "9",
       "MaxLength": "18",
@@ -43,489 +30,153 @@
       "ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x."
     }
   },
-  "Mappings": {
-    "RegionMap": {
-      "us-east-1": {
-        "AMI": "ami-7f418316"
-      },
-      "us-west-1": {
-        "AMI": "ami-951945d0"
-      },
-      "us-west-2": {
-        "AMI": "ami-16fd7026"
-      },
-      "eu-west-1": {
-        "AMI": "ami-24506250"
-      },
-      "sa-east-1": {
-        "AMI": "ami-3e3be423"
-      },
-      "ap-southeast-1": {
-        "AMI": "ami-74dda626"
-      },
-      "ap-southeast-2": {
-        "AMI": "ami-b3990e89"
-      },
-      "ap-northeast-1": {
-        "AMI": "ami-dcfa4edd"
-      }
+
+  "Mappings" : {
+    "AWSInstanceType2Arch" : {
+      "t1.micro"    : { "Arch" : "PV64"   },
+      "t2.nano"     : { "Arch" : "HVM64"  },
+      "t2.micro"    : { "Arch" : "HVM64"  },
+      "t2.small"    : { "Arch" : "HVM64"  },
+      "t2.medium"   : { "Arch" : "HVM64"  },
+      "t2.large"    : { "Arch" : "HVM64"  }
+    },
+
+    "AWSInstanceType2NATArch" : {
+      "t1.micro"    : { "Arch" : "NATPV64"   },
+      "t2.nano"     : { "Arch" : "NATHVM64"  },
+      "t2.micro"    : { "Arch" : "NATHVM64"  },
+      "t2.small"    : { "Arch" : "NATHVM64"  },
+      "t2.medium"   : { "Arch" : "NATHVM64"  },
+      "t2.large"    : { "Arch" : "NATHVM64"  }
     }
+,
+    "AWSRegionArch2AMI" : {
+      "us-east-1"        : {"HVM64" : "ami-c60b90d1"},
+      "us-west-2"        : {"HVM64" : "ami-f701cb97"},
+      "us-west-1"        : {"HVM64" : "ami-1bf0b37b"}
+    }
+
   },
-  "Resources": {
-    "VPC": {
-      "Type": "AWS::EC2::VPC",
-      "Properties": {
-        "CidrBlock": "10.0.0.0/16",
-        "Tags": [
-          {
-            "Key": "Application",
-            "Value": {
-              "Ref": "AWS::StackId"
-            }
-          }
-        ]
-      }
-    },
-    "Subnet": {
-      "Type": "AWS::EC2::Subnet",
-      "Properties": {
-        "VpcId": {
-          "Ref": "VPC"
-        },
-        "CidrBlock": "10.0.0.0/24",
-        "Tags": [
-          {
-            "Key": "Application",
-            "Value": {
-              "Ref": "AWS::StackId"
-            }
-          }
-        ]
-      }
-    },
-    "InternetGateway": {
-      "Type": "AWS::EC2::InternetGateway",
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "Application",
-            "Value": {
-              "Ref": "AWS::StackId"
-            }
-          }
-        ]
-      }
-    },
-    "AttachGateway": {
-      "Type": "AWS::EC2::VPCGatewayAttachment",
-      "Properties": {
-        "VpcId": {
-          "Ref": "VPC"
-        },
-        "InternetGatewayId": {
-          "Ref": "InternetGateway"
-        }
-      }
-    },
-    "RouteTable": {
-      "Type": "AWS::EC2::RouteTable",
-      "Properties": {
-        "VpcId": {
-          "Ref": "VPC"
-        },
-        "Tags": [
-          {
-            "Key": "Application",
-            "Value": {
-              "Ref": "AWS::StackId"
-            }
-          }
-        ]
-      }
-    },
-    "Route": {
-      "Type": "AWS::EC2::Route",
-      "DependsOn": "AttachGateway",
-      "Properties": {
-        "RouteTableId": {
-          "Ref": "RouteTable"
-        },
-        "DestinationCidrBlock": "0.0.0.0/0",
-        "GatewayId": {
-          "Ref": "InternetGateway"
-        }
-      }
-    },
-    "SubnetRouteTableAssociation": {
-      "Type": "AWS::EC2::SubnetRouteTableAssociation",
-      "Properties": {
-        "SubnetId": {
-          "Ref": "Subnet"
-        },
-        "RouteTableId": {
-          "Ref": "RouteTable"
-        }
-      }
-    },
-    "NetworkAcl": {
-      "Type": "AWS::EC2::NetworkAcl",
-      "Properties": {
-        "VpcId": {
-          "Ref": "VPC"
-        },
-        "Tags": [
-          {
-            "Key": "Application",
-            "Value": {
-              "Ref": "AWS::StackId"
-            }
-          }
-        ]
-      }
-    },
-    "InboundHTTPNetworkAclEntry": {
-      "Type": "AWS::EC2::NetworkAclEntry",
-      "Properties": {
-        "NetworkAclId": {
-          "Ref": "NetworkAcl"
-        },
-        "RuleNumber": "100",
-        "Protocol": "6",
-        "RuleAction": "allow",
-        "Egress": "false",
-        "CidrBlock": "0.0.0.0/0",
-        "PortRange": {
-          "From": "80",
-          "To": "80"
-        }
-      }
-    },
-    "InboundSSHNetworkAclEntry": {
-      "Type": "AWS::EC2::NetworkAclEntry",
-      "Properties": {
-        "NetworkAclId": {
-          "Ref": "NetworkAcl"
-        },
-        "RuleNumber": "101",
-        "Protocol": "6",
-        "RuleAction": "allow",
-        "Egress": "false",
-        "CidrBlock": "0.0.0.0/0",
-        "PortRange": {
-          "From": "22",
-          "To": "22"
-        }
-      }
-    },
-    "InboundResponsePortsNetworkAclEntry": {
-      "Type": "AWS::EC2::NetworkAclEntry",
-      "Properties": {
-        "NetworkAclId": {
-          "Ref": "NetworkAcl"
-        },
-        "RuleNumber": "102",
-        "Protocol": "6",
-        "RuleAction": "allow",
-        "Egress": "false",
-        "CidrBlock": "0.0.0.0/0",
-        "PortRange": {
-          "From": "1024",
-          "To": "65535"
-        }
-      }
-    },
-    "OutBoundHTTPNetworkAclEntry": {
-      "Type": "AWS::EC2::NetworkAclEntry",
-      "Properties": {
-        "NetworkAclId": {
-          "Ref": "NetworkAcl"
-        },
-        "RuleNumber": "100",
-        "Protocol": "6",
-        "RuleAction": "allow",
-        "Egress": "true",
-        "CidrBlock": "0.0.0.0/0",
-        "PortRange": {
-          "From": "80",
-          "To": "80"
-        }
-      }
-    },
-    "OutBoundHTTPSNetworkAclEntry": {
-      "Type": "AWS::EC2::NetworkAclEntry",
-      "Properties": {
-        "NetworkAclId": {
-          "Ref": "NetworkAcl"
-        },
-        "RuleNumber": "101",
-        "Protocol": "6",
-        "RuleAction": "allow",
-        "Egress": "true",
-        "CidrBlock": "0.0.0.0/0",
-        "PortRange": {
-          "From": "443",
-          "To": "443"
-        }
-      }
-    },
-    "OutBoundResponsePortsNetworkAclEntry": {
-      "Type": "AWS::EC2::NetworkAclEntry",
-      "Properties": {
-        "NetworkAclId": {
-          "Ref": "NetworkAcl"
-        },
-        "RuleNumber": "102",
-        "Protocol": "6",
-        "RuleAction": "allow",
-        "Egress": "true",
-        "CidrBlock": "0.0.0.0/0",
-        "PortRange": {
-          "From": "1024",
-          "To": "65535"
-        }
-      }
-    },
-    "SubnetNetworkAclAssociation": {
-      "Type": "AWS::EC2::SubnetNetworkAclAssociation",
-      "Properties": {
-        "SubnetId": {
-          "Ref": "Subnet"
-        },
-        "NetworkAclId": {
-          "Ref": "NetworkAcl"
-        }
-      }
-    },
-    "IPAddress": {
-      "Type": "AWS::EC2::EIP",
-      "DependsOn": "AttachGateway",
-      "Properties": {
-        "Domain": "vpc",
-        "InstanceId": {
-          "Ref": "WebServerInstance"
-        }
-      }
-    },
-    "InstanceSecurityGroup": {
-      "Type": "AWS::EC2::SecurityGroup",
-      "Properties": {
-        "VpcId": {
-          "Ref": "VPC"
-        },
-        "GroupDescription": "Enable SSH access via port 22",
-        "SecurityGroupIngress": [
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "22",
-            "ToPort": "22",
-            "CidrIp": {
-              "Ref": "SSHLocation"
+
+  "Resources" : {
+
+    "WebServer": {
+      "Type": "AWS::EC2::Instance",
+      "Metadata" : {
+        "AWS::CloudFormation::Init" : {
+          "configSets" : {
+            "full_install" : [ "install_cfn", "install_dse" ]
+          },
+
+          "install_cfn" : {
+            "files" : {
+              "/etc/cfn/cfn-hup.conf" : {
+                "content" : { "Fn::Join" : ["", [
+                  "[main]\n",
+                  "stack=", { "Ref" : "AWS::StackId" }, "\n",
+                  "region=", { "Ref" : "AWS::Region" }, "\n"
+                ]]},
+                "mode"    : "000400",
+                "owner"   : "root",
+                "group"   : "root"
+              },
+
+              "/etc/cfn/hooks.d/cfn-auto-reloader.conf" : {
+                "content": { "Fn::Join" : ["", [
+                  "[cfn-auto-reloader-hook]\n",
+                  "triggers=post.update\n",
+                  "path=Resources.WebServer.Metadata.AWS::CloudFormation::Init\n",
+                  "action=/usr/local/bin/cfn-init -v ",
+                  "         --stack ", { "Ref" : "AWS::StackName" },
+                  "         --resource WebServer ",
+                  "         --configsets full_install ",
+                  "         --region ", { "Ref" : "AWS::Region" }, "\n",
+                  "runas=root\n"
+                ]]}
+              }
+            },
+
+            "services" : {
+              "sysvinit" : {
+                "cfn-hup" : { "enabled" : "true", "ensureRunning" : "true",
+                              "files" : ["/etc/cfn/cfn-hup.conf", "/etc/cfn/hooks.d/cfn-auto-reloader.conf"]}
+              }
             }
           },
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "80",
-            "ToPort": "80",
-            "CidrIp": "0.0.0.0/0"
-          }
-        ]
-      }
-    },
-    "WebServerInstance": {
-      "Type": "AWS::EC2::Instance",
-      "Metadata": {
-        "Comment": "Install a simple PHP application",
-        "AWS::CloudFormation::Init": {
-          "config": {
-            "packages": {
-              "yum": {
-                "httpd": [],
-                "php": []
-              }
-            },
-            "files": {
-              "/var/www/html/index.php": {
-                "content": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "<?php\n",
-                      "echo '<h1>AWS CloudFormation sample PHP application</h1>';\n",
-                      "?>\n"
-                    ]
-                  ]
-                },
-                "mode": "000644",
-                "owner": "apache",
-                "group": "apache"
-              },
-              "/etc/cfn/cfn-hup.conf": {
-                "content": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "[main]\n",
-                      "stack=",
-                      {
-                        "Ref": "AWS::StackId"
-                      },
-                      "\n",
-                      "region=",
-                      {
-                        "Ref": "AWS::Region"
-                      },
-                      "\n"
-                    ]
-                  ]
-                },
-                "mode": "000400",
-                "owner": "root",
-                "group": "root"
-              },
-              "/etc/cfn/hooks.d/cfn-auto-reloader.conf": {
-                "content": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "[cfn-auto-reloader-hook]\n",
-                      "triggers=post.update\n",
-                      "path=Resources.WebServerInstance.Metadata.AWS::CloudFormation::Init\n",
-                      "action=/opt/aws/bin/cfn-init -s ",
-                      {
-                        "Ref": "AWS::StackId"
-                      },
-                      " -r WebServerInstance ",
-                      " --region     ",
-                      {
-                        "Ref": "AWS::Region"
-                      },
-                      "\n",
-                      "runas=root\n"
-                    ]
-                  ]
-                }
-              }
-            },
-            "services": {
-              "sysvinit": {
-                "httpd": {
-                  "enabled": "true",
-                  "ensureRunning": "true"
-                },
-                "sendmail": {
-                  "enabled": "false",
-                  "ensureRunning": "false"
-                }
+          "install_dse" : {
+            "commands" : {
+              "01_install_dse" : {
+                "command" : { "Fn::Join" : ["", [
+                  "#!/usr/bin/env bash \n",
+                  "cloud_type=\"aws\" \n",
+                  "data_center_name=\"dc0\" \n",
+                  "seed_node_dns_name=\"dc0vm0\" \n",
+                  "echo \"Configuring nodes with the settings:\" \n",
+                  "echo cloud_type $cloud_type \n",
+                  "echo seed_node_dns_name $seed_node_dns_name \n",
+                  "apt-get -y install unzip \n",
+                  "wget https://github.com/DSPN/install-datastax-ubuntu/archive/5.0.1-4.zip \n",
+                  "unzip 5.0.1-4.zip \n",
+                  "cd install-datastax-ubuntu-5.0.1-4/bin \n",
+                  "./dse.sh $cloud_type $seed_node_dns_name $data_center_name \n"
+                  ]]},
               }
             }
           }
         }
       },
       "Properties": {
-        "ImageId": {
-          "Fn::FindInMap": [
-            "RegionMap",
-            {
-              "Ref": "AWS::Region"
-            },
-            "AMI"
-          ]
-        },
-        "SecurityGroupIds": [
-          {
-            "Ref": "InstanceSecurityGroup"
-          }
-        ],
-        "SubnetId": {
-          "Ref": "Subnet"
-        },
-        "InstanceType": {
-          "Ref": "InstanceType"
-        },
-        "KeyName": {
-          "Ref": "KeyName"
-        },
-        "Tags": [
-          {
-            "Key": "Application",
-            "Value": {
-              "Ref": "AWS::StackId"
-            }
-          }
-        ],
-        "UserData": {
-          "Fn::Base64": {
-            "Fn::Join": [
-              "",
-              [
-                "#!/bin/bash\n",
-                "yum update -y aws-cfn-bootstrap\n",
-                "# Helper function\n",
-                "function error_exit\n",
-                "{\n",
-                "  /opt/aws/bin/cfn-signal -e 1 -r \"$1\" '",
-                {
-                  "Ref": "WebServerWaitHandle"
-                },
-                "'\n",
-                "  exit 1\n",
-                "}\n",
-                "# Install the simple web page\n",
-                "/opt/aws/bin/cfn-init -s ",
-                {
-                  "Ref": "AWS::StackId"
-                },
-                " -r WebServerInstance ",
-                "         --region ",
-                {
-                  "Ref": "AWS::Region"
-                },
-                " || error_exit 'Failed to run cfn-init'\n",
-                "# Start up the cfn-hup daemon to listen for changes to the Web Server metadata\n",
-                "/opt/aws/bin/cfn-hup || error_exit 'Failed to start cfn-hup'\n",
-                "# All done so signal success\n",
-                "/opt/aws/bin/cfn-signal -e 0 -r \"WebServer setup complete\" '",
-                {
-                  "Ref": "WebServerWaitHandle"
-                },
-                "'\n"
-              ]
-            ]
-          }
+        "ImageId" : { "Fn::FindInMap" : [ "AWSRegionArch2AMI", { "Ref" : "AWS::Region" },
+                          { "Fn::FindInMap" : [ "AWSInstanceType2Arch", { "Ref" : "InstanceType" }, "Arch" ] } ] },
+        "InstanceType"   : { "Ref" : "InstanceType" },
+        "SecurityGroups" : [ {"Ref" : "WebServerSecurityGroup"} ],
+        "KeyName"        : { "Ref" : "KeyName" },
+        "UserData"       : { "Fn::Base64" : { "Fn::Join" : ["", [
+          "#!/bin/bash -xe\n",
+          "apt-get update\n",
+          "apt-get -y install python-setuptools python-pip\n",
+          "pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz \n",
+          "ln -s /usr/local/init/ubuntu/cfn-hup /etc/init.d/cfn-hup \n",
+          "chmod 775 /usr/local/init/ubuntu/cfn-hup \n",
+          "update-rc.d cfn-hup defaults \n",
+          "/usr/local/bin/cfn-init -v ",
+          "         --stack ", { "Ref" : "AWS::StackId" },
+          "         --resource WebServer ",
+          "         --configsets full_install ",
+          "         --region ", { "Ref" : "AWS::Region" }, "\n",
+          "/usr/local/bin/cfn-signal -e $? ",
+          "         --stack ", { "Ref" : "AWS::StackId" },
+          "         --resource WebServer ",
+          "         --region ", { "Ref" : "AWS::Region" }, "\n"
+        ]]}}
+      },
+
+      "CreationPolicy" : {
+        "ResourceSignal" : {
+          "Timeout" : "PT30M"
         }
       }
+
     },
-    "WebServerWaitHandle": {
-      "Type": "AWS::CloudFormation::WaitConditionHandle"
-    },
-    "WebServerWaitCondition": {
-      "Type": "AWS::CloudFormation::WaitCondition",
-      "DependsOn": "WebServerInstance",
-      "Properties": {
-        "Handle": {
-          "Ref": "WebServerWaitHandle"
-        },
-        "Timeout": "300"
+
+    "WebServerSecurityGroup" : {
+      "Type" : "AWS::EC2::SecurityGroup",
+      "Properties" : {
+        "GroupDescription" : "Enable HTTP and SSH access",
+        "SecurityGroupIngress" : [
+          {"IpProtocol" : "tcp", "FromPort" : "80", "ToPort" : "80", "CidrIp" : "0.0.0.0/0"},
+          {"IpProtocol" : "tcp", "FromPort" : "22", "ToPort" : "22", "CidrIp" : { "Ref" : "SSHLocation"}},
+          {"IpProtocol" : "tcp", "FromPort" : "8888", "ToPort" : "8888", "CidrIp" : "0.0.0.0/0"},
+
+        ]
       }
     }
   },
-  "Outputs": {
-    "URL": {
-      "Value": {
-        "Fn::Join": [
-          "",
-          [
-            "http://",
-            {
-              "Fn::GetAtt": [
-                "WebServerInstance",
-                "PublicIp"
-              ]
-            }
-          ]
-        ]
-      },
-      "Description": "Newly created application URL"
+
+  "Outputs" : {
+    "WebsiteURL" : {
+      "Value" : { "Fn::Join" : ["", ["http://", { "Fn::GetAtt" : [ "WebServer", "PublicDnsName" ]}, ":8888" ]] },
+      "Description" : "URL for OpsCenter"
     }
   }
 }


### PR DESCRIPTION
The json template was trimmed down from the example Rails template. Besides general polish there are a few known issues:

- the *install_dse* command contains no test
- the output of *dse.sh* doesn't seem to be getting logged correctly?
- params like *cluster_name* aren't being passed to the template
- valid instance types, regions, machine images where reduce in the template and should be added back

But it does work, see readme for example output.

Edit: Forgot to mention issue, unlike the Rails example which installs cfn-hup with yum there's no .deb package. So we're grabbing the latest source and installing with pip. Should look for a .deb version or pin a version and not grab *latest*?